### PR TITLE
Point the private api link to proper url

### DIFF
--- a/app/scripts/controllers/gene.js
+++ b/app/scripts/controllers/gene.js
@@ -3297,15 +3297,16 @@ angular.module('oncokbApp')
                 $scope.mapScope = {};
                 var deferred1 = $q.defer();
                 $firebaseObject(firebase.database().ref("Genes/" + $routeParams.geneName)).$bindTo($scope, "gene").then(function () {
-                    DatabaseConnector.getAllInternalGenes().then(function(genes) {
+                    DatabaseConnector.getAllGenes().then(function(genes) {
                         $scope.meta.gene = _.find(genes.data, function(gene) {
                             return gene.hugoSymbol === $scope.gene.name;
                         });
                         $scope.status.geneReleased = ($scope.meta.gene === undefined) ? 'no' : 'yes';
                     }, function(reason) {
                         // nothing really needs to be done
+                    }).finally(function() {
+                        deferred1.resolve();
                     });
-                    deferred1.resolve();
                 }, function (error) {
                     deferred1.reject(error);
                 });

--- a/app/scripts/factories/VariantFactory.js
+++ b/app/scripts/factories/VariantFactory.js
@@ -29,7 +29,7 @@ angular.module('oncokbApp').factory('TumorType', ['$http', 'OncoKB', function($h
 angular.module('oncokbApp').factory('Gene', ['$http', 'OncoKB', function($http, OncoKB) {
     'use strict';
 
-    function getFromServer() {
+    function getCurationGenes() {
         return $http.get(OncoKB.config.curationLink + 'gene.json');
     }
 
@@ -48,7 +48,7 @@ angular.module('oncokbApp').factory('Gene', ['$http', 'OncoKB', function($http, 
     }
 
     return {
-        getFromServer: getFromServer,
+        getCurationGenes: getCurationGenes,
         getAllInternalGenes: getAllInternalGenes,
         remove: remove
     };
@@ -425,16 +425,14 @@ angular.module('oncokbApp')
         'use strict';
 
         function getSuggestedVariants() {
-            return $http.get(OncoKB.config.privateApiLink +
-                'utils/suggestedVariants');
+            return $http.get(OncoKB.config.privateApiLink + 'utils/suggestedVariants');
         }
 
         function isHotspot(hugoSymbol, variant) {
             if (!hugoSymbol || !variant) {
                 return null;
             }
-            return $http.get(OncoKB.config.privateApiLink +
-                'utils/isHotspot?hugoSymbol=' +
+            return $http.get(OncoKB.config.privateApiLink + 'utils/isHotspot?hugoSymbol=' +
                 hugoSymbol + '&variant=' + variant);
         }
 
@@ -450,7 +448,7 @@ angular.module('oncokbApp')
                 acc.push(key + '=' +value);
                 return acc;
             }, []).join('&');
-            return $http.get(OncoKB.config.privateApiLink + 'utils/variantAnnotation?' + paramsStr);
+            return $http.get(OncoKB.config.internalPrivateApiLink + 'utils/variantAnnotation?' + paramsStr);
         }
 
         return {

--- a/app/scripts/services/databaseconnector.js
+++ b/app/scripts/services/databaseconnector.js
@@ -83,8 +83,8 @@ angular.module('oncokbApp')
                 return deferred.promise;
             }
 
-            function getAllGene(callback, timestamp) {
-                Gene.getFromServer()
+            function getAllGenes(callback, timestamp) {
+                Gene.getCurationGenes()
                     .then(function(data) {
                         if (timestamp) {
                             numOfLocks[timestamp]--;
@@ -562,7 +562,7 @@ angular.module('oncokbApp')
                 numOfLocks[timestamp] = 2;
                 data[timestamp] = {};
 
-                getAllGene(function(d) {
+                getAllGenes(function(d) {
                     data[timestamp].genes = d.data;
                 }, timestamp);
                 getAllTumorType(function(d) {
@@ -611,6 +611,13 @@ angular.module('oncokbApp')
                 },
                 updateGeneCache: function(hugoSymbol) {
                     return updateGeneCache(hugoSymbol);
+                },
+                getAllGenes: function() {
+                    if ($rootScope.internal) {
+                        return Gene.getAllInternalGenes();
+                    } else {
+                        return Gene.getCurationGenes();
+                    }
                 },
                 getAllInternalGenes: getAllInternalGenes,
                 getOncoTreeTumorTypesByMainType: getOncoTreeTumorTypesByMainType,


### PR DESCRIPTION
The current way of assigning API is incapable of the work flow. These are five api links(`api_link`, `curation_link`, `private_link`, `public_api_link`, `internal_private_link`) are curated inappropriately and should be adjusted going forward. But since we are going to add the authentication soon which should solve all the issues. So I'm not going to make big changes in this round but simple hack fixes.