### PR TITLE
Remove DriveOncokbInfo service

### DIFF
--- a/app/scripts/factories/VariantFactory.js
+++ b/app/scripts/factories/VariantFactory.js
@@ -66,10 +66,16 @@ angular.module('oncokbApp').factory('DataSummary', ['$http', function($http) {
     function getEvidenceByType(type) {
         return $http.get(OncoKB.config.publicApiLink + 'evidences/lookup?source=oncotree&evidenceTypes=' + type);
     }
+
+    function getEvidenceLevels() {
+        return $http.get(OncoKB.config.publicApiLink + 'info');
+    }
+
     return {
         getFromServer: getFromServer,
         getGeneType: getGeneType,
-        getEvidenceByType: getEvidenceByType
+        getEvidenceByType: getEvidenceByType,
+        getEvidenceLevels: getEvidenceLevels,
     };
 }]);
 
@@ -122,23 +128,6 @@ angular.module('oncokbApp').factory('Alteration', ['$http', 'OncoKB', function($
     return {
         findByGene: findByGene,
         getFromServer: getFromServer
-    };
-}]);
-
-angular.module('oncokbApp').factory('DriveOncokbInfo', ['$http', 'OncoKB', function($http, OncoKB) {
-    'use strict';
-
-    function getFromServer() {
-        return $http.get(OncoKB.config.curationLink + 'oncokbInfo.json');
-    }
-
-    function getEvidenceLevels() {
-        return $http.get(OncoKB.config.publicApiLink + 'info');
-    }
-
-    return {
-        getFromServer: getFromServer,
-        getEvidenceLevels: getEvidenceLevels
     };
 }]);
 

--- a/app/scripts/services/databaseconnector.js
+++ b/app/scripts/services/databaseconnector.js
@@ -10,7 +10,6 @@ angular.module('oncokbApp')
         'TumorType',
         'Evidence',
         'SearchVariant',
-        'DriveOncokbInfo',
         'DriveAnnotation',
         'SendEmail',
         'onLocalhost',
@@ -30,7 +29,6 @@ angular.module('oncokbApp')
                  TumorType,
                  Evidence,
                  SearchVariant,
-                 DriveOncokbInfo,
                  DriveAnnotation,
                  SendEmail,
                  onLocalhost,
@@ -584,7 +582,7 @@ angular.module('oncokbApp')
             }
 
             function getEvidenceLevels(success, fail) {
-                DriveOncokbInfo
+                DataSummary
                     .getEvidenceLevels()
                     .then(function(result) {
                         success(result.data);


### PR DESCRIPTION
The service is used to fetch oncokb users info stored in google spreadsheet which is used in previous version of the curation platform