### PR TITLE
Make error validation test collapsible

### DIFF
--- a/app/views/tools.html
+++ b/app/views/tools.html
@@ -250,21 +250,26 @@
                         ng-class="{'active':dataValidation.type === type.key}" ng-click="dataValidation.type=type.key">
                         <a>{{type.name}}</a></li>
                 </ul>
-                <div ng-repeat="type in dataValidationTypes" class="data-validation-table">
+                <div ng-repeat="type in dataValidationTypes" class="data-validation-table" >
                     <div
                         ng-show="dataValidation.type === type.key"
                         style="border: 1px solid lightgrey; border-radius: 5px; padding: 5px 10px; margin: 5px 0"
-                        ng-repeat="test in dataValidation.data[type.key]">
-                        <div>
+                        ng-repeat="test in dataValidation.data[type.key]"
+                        ng-init="collapsed=true"
+                    >
+                        <div ng-click="collapsed=!collapsed">
                         <span ng-show="test.status === 'IS_PENDING'"><i
                             class="fa fa-spinner fa-spin"></i></span>
-                            <span ng-show="test.status === 'IS_COMPLETE'"><i class="fa fa-check-circle"
-                                                                             style="color:green"></i></span>
-                            <span ng-show="test.status === 'IS_ERROR'"><i
-                                class="fa fa-exclamation-triangle" style="color: red"></i></span>
-                            <span style="margin-left: 5px">{{test.key}}</span>
-                        </div>
-                        <div ng-if="test.data.length > 0">
+                        <span ng-show="test.status === 'IS_COMPLETE'"><i class="fa fa-check-circle"
+                                                                         style="color:green"></i></span>
+                        <span ng-show="test.status === 'IS_ERROR'">
+                            <i class="fa fa fa-angle-right" ng-if="collapsed"></i>
+                            <i class="fa fa fa-angle-down" ng-if="!collapsed"></i>
+                            <i class="fa fa-exclamation-triangle" style="color: red"></i>
+                        </span>
+                        <span style="margin-left: 5px">{{test.key}}</span>
+                    </div>
+                        <div ng-if="test.data.length > 0" ng-show="!collapsed">
                             <table class="table table-striped">
                                 <thead>
                                 <tr>


### PR DESCRIPTION
With additional tests to be added into the system, collapsing sections comes more relevant and necessary.
By default, collapse all sections.

**Default**
![Screen Shot 2023-06-12 at 4 08 47 PM](https://github.com/oncokb/curation-platform/assets/5400599/76af9703-98c1-49e6-a18e-9b3bd571795a)
**Open error section**
![Screen Shot 2023-06-12 at 4 08 53 PM](https://github.com/oncokb/curation-platform/assets/5400599/2a22ff7a-5d7c-4797-bfab-acb3669161ed)
